### PR TITLE
fix: 改进错误处理，修复ctx.memorytable.clearTrait的误调用）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1621,8 +1621,13 @@ async function createRequest(config, session, customConfig = {}, apiMode) {
                 session.send(`请求失败，状态码: ${response.status}`);
             }
         } catch (error) {
-            console.error("请求错误:", error);
-            session.send(`请求错误: ${error.message}`);
+            // console.error("请求错误:", error);
+            // session.send(`请求错误: ${error.message}`);
+            const errorMessage = error.toString() || error.message;
+            const consoleError = error.response ? error.response.data : errorMessage;
+            const sendError = error.response ? JSON.stringify(error.response.data, null, 2) : errorMessage;
+            logger.error('请求错误:', consoleError);
+            session.send(`请求错误: ${sendError}`);
         }
     }
 
@@ -1720,8 +1725,13 @@ async function createRequest(config, session, customConfig = {}, apiMode) {
                 session.send(`请求失败，状态码: ${response.status}`);
             }
         } catch (error) {
-            console.error("请求错误:", error);
-            session.send(`请求错误: ${error.message}`);
+            // console.error("请求错误:", error);
+            // session.send(`请求错误: ${error.message}`);
+            const errorMessage = error.toString() || error.message;
+            const consoleError = error.response ? error.response.data : errorMessage;
+            const sendError = error.response ? JSON.stringify(error.response.data, null, 2) : errorMessage;
+            logger.error('请求错误:', consoleError);
+            session.send(`请求错误: ${sendError}`);
         }
     }
 
@@ -1815,8 +1825,13 @@ async function createRequest(config, session, customConfig = {}, apiMode) {
                 session.send(`请求失败，状态码: ${response.status}`);
             }
         } catch (error) {
-            console.error("请求错误:", error);
-            session.send(`请求错误: ${error.message}`);
+            // console.error("请求错误:", error);
+            // session.send(`请求错误: ${error.message}`);
+            const errorMessage = error.toString() || error.message;
+            const consoleError = error.response ? error.response.data : errorMessage;
+            const sendError = error.response ? JSON.stringify(error.response.data, null, 2) : errorMessage;
+            logger.error('请求错误:', consoleError);
+            session.send(`请求错误: ${sendError}`);
         }
     }
 
@@ -1912,8 +1927,13 @@ async function createRequest(config, session, customConfig = {}, apiMode) {
                 session.send(`请求失败`);
             }
         } catch (error) {
-            console.error("请求错误:", error);
-            session.send(`请求错误: ${error.message}`);
+            // console.error("请求错误:", error);
+            // session.send(`请求错误: ${error.message}`);
+            const errorMessage = error.toString() || error.message;
+            const consoleError = error.response ? error.response.data : errorMessage;
+            const sendError = error.response ? JSON.stringify(error.response.data, null, 2) : errorMessage;
+            logger.error('请求错误:', consoleError);
+            session.send(`请求错误: ${sendError}`);
         }
     }
     if (!api_select) {
@@ -2007,8 +2027,13 @@ async function createRequest(config, session, customConfig = {}, apiMode) {
                 session.send(`请求失败，状态码: ${response.status}`);
             }
         } catch (error) {
-            console.error("请求错误:", error);
-            session.send(`请求错误: ${error.message}`);
+            // console.error("请求错误:", error);
+            // session.send(`请求错误: ${error.message}`);
+            const errorMessage = error.toString() || error.message;
+            const consoleError = error.response ? error.response.data : errorMessage;
+            const sendError = error.response ? JSON.stringify(error.response.data, null, 2) : errorMessage;
+            logger.error('请求错误:', consoleError);
+            session.send(`请求错误: ${sendError}`);
         }
     }
     if (!api_select) {
@@ -4276,7 +4301,7 @@ async function apply(ctx, config) {
             let speakerId = sessionData.speakerId;
             let sessionId = await buildSessionId(session, config, characterName, speakerId);
             cancelUserAlarms(sessionId)// 停止闹钟
-            ctx.memorytable.clearTrait(session);//重置记忆表格
+            if (config.memory_table) { ctx.memorytable.clearTrait(session); } // 重置记忆表格
             await session.send(`已删除历史记录文件：${decodeURIComponent(fileToDelete)}\n现在可以使用oob.load（别名：加载人设）来选择新的人设了。`);
         });
 
@@ -4304,7 +4329,7 @@ async function apply(ctx, config) {
                 let speakerId = sessionData.speakerId;
                 let sessionId = await buildSessionId(session, config, characterName, speakerId);
                 cancelUserAlarms(sessionId)// 停止闹钟
-                ctx.memorytable.clearTrait(session); //重置记忆表格
+                if (config.memory_table) { ctx.memorytable.clearTrait(session); } // 重置记忆表格
                 //向量库
                 if (fs.existsSync(`${__dirname}/database/${file}`)) {
                     const filePath = `${__dirname}/database/${file}`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4301,7 +4301,7 @@ async function apply(ctx, config) {
             let speakerId = sessionData.speakerId;
             let sessionId = await buildSessionId(session, config, characterName, speakerId);
             cancelUserAlarms(sessionId)// 停止闹钟
-            if (config.memory_table) { ctx.memorytable.clearTrait(session); } // 重置记忆表格
+            ctx.memorytable?.clearTrait(session); // 重置记忆表格
             await session.send(`已删除历史记录文件：${decodeURIComponent(fileToDelete)}\n现在可以使用oob.load（别名：加载人设）来选择新的人设了。`);
         });
 
@@ -4329,7 +4329,7 @@ async function apply(ctx, config) {
                 let speakerId = sessionData.speakerId;
                 let sessionId = await buildSessionId(session, config, characterName, speakerId);
                 cancelUserAlarms(sessionId)// 停止闹钟
-                if (config.memory_table) { ctx.memorytable.clearTrait(session); } // 重置记忆表格
+                ctx.memorytable?.clearTrait(session); // 重置记忆表格
                 //向量库
                 if (fs.existsSync(`${__dirname}/database/${file}`)) {
                     const filePath = `${__dirname}/database/${file}`;


### PR DESCRIPTION
修复问题：

1. 原先错误提示不会显示具体错误原因，导致排故困难，现在修改为了控制台显示错误的信息，且bot会发送错误的信息
2. 原先的重置人设及删除人设人设中有调用ctx.memorytable.clearTrait，但并未判断是否启用了memoryTable插件。当遇到未启用memoryTable插件的时候，ctx下没有memorytable属性，会导致报错，无法继续执行接下来的逻辑）